### PR TITLE
Add comma in the template.json

### DIFF
--- a/templates/templates.json
+++ b/templates/templates.json
@@ -3,7 +3,7 @@
   "dockerfiles" : [
     { "name": "node.dockerfile.template", "url" : "https://raw.githubusercontent.com/cloud66/starter/{{.branch}}/templates/node.dockerfile.template"},
     { "name": "python.dockerfile.template", "url" : "https://raw.githubusercontent.com/cloud66/starter/{{.branch}}/templates/python.dockerfile.template"},
-    { "name": "ruby.dockerfile.template", "url" : "https://raw.githubusercontent.com/cloud66/starter/{{.branch}}/templates/ruby.dockerfile.template"}
+    { "name": "ruby.dockerfile.template", "url" : "https://raw.githubusercontent.com/cloud66/starter/{{.branch}}/templates/ruby.dockerfile.template"},
     { "name": "php.dockerfile.template", "url" : "https://raw.githubusercontent.com/cloud66/starter/{{.branch}}/templates/php.dockerfile.template"}
   ],
   "service-ymls" : [


### PR DESCRIPTION
I have an error:
```
starter
 Cloud 66 Starter ~ (c) 2016 Cloud 66
 Checking templates in /Users/snuff/.starter
 ----> Downloading from https://raw.githubusercontent.com/cloud66/starter/master/templates/templates.json
 Failed to download latest templates due to invalid character '{' after array element
```
So, there is no comma after the ruby link in the template.json

This PR fix it.